### PR TITLE
refactor(peer): do not implement RTPMediaExtensions

### DIFF
--- a/src/rtc/peer-manager/events.ts
+++ b/src/rtc/peer-manager/events.ts
@@ -3,11 +3,24 @@ import { IdentifiableEvent } from '../../util/identifiable-event';
 import {
   RTCPeerCandidateEvent,
   RTCPeerDescriptionEvent,
-  RTCPeerStreamsEvent
 } from '../peer/events';
 
 export type RTCPeerManagerEventMap = {
   candidate: IdentifiableEvent<RTCPeerCandidateEvent>,
   description: IdentifiableEvent<RTCPeerDescriptionEvent>,
-  streams: IdentifiableEvent<RTCPeerStreamsEvent>
+  streams: IdentifiableEvent<RTCPeerManagerStreamsEvent>
 }
+
+/**
+ * Contains a readonly array of [[MediaStream]]'s forwarded from an [[RTCPeerConnection]] instance.
+ *
+ * A listener of this event would be the "receiver" of the contained streams, i.e. not the "sender".
+ *
+ * @noInheritDoc
+ */
+export class RTCPeerManagerStreamsEvent extends Event {
+  constructor(public streams: ReadonlyArray<MediaStream>) {
+    super("streams");
+  }
+}
+

--- a/src/rtc/peer/events.ts
+++ b/src/rtc/peer/events.ts
@@ -1,7 +1,6 @@
 export type RTCPeerEventMap = {
   candidate: RTCPeerCandidateEvent;
   description: RTCPeerDescriptionEvent;
-  streams: RTCPeerStreamsEvent;
 };
 
 /**
@@ -26,15 +25,3 @@ export class RTCPeerDescriptionEvent extends Event {
   }
 }
 
-/**
- * Contains a readonly array of [[MediaStream]]'s forwarded from an [[RTCPeerConnection]] instance.
- *
- * A listener of this event would be the "receiver" of the contained streams, i.e. not the "sender".
- *
- * @noInheritDoc
- */
-export class RTCPeerStreamsEvent extends Event {
-  constructor(public streams: ReadonlyArray<MediaStream>) {
-    super("streams");
-  }
-}


### PR DESCRIPTION
Instead, provide the connection in a prop `media` declared as RTPMediaExtensions.

Closes #8