### PR TITLE
Improve docs for RTPMediaExtensions via refactor

### DIFF
--- a/src/rtc/peer/interfaces.ts
+++ b/src/rtc/peer/interfaces.ts
@@ -4,19 +4,12 @@ type RTPMediaExtensionsEventMap = {
   track: RTCTrackEvent
 };
 
-interface RTPMediaExtensionsEventTarget extends TypedEventTarget<RTPMediaExtensionsEventMap> {
+export interface RTPMediaExtensions extends TypedEventTarget<RTPMediaExtensionsEventMap> {
+    getReceivers(): RTCRtpReceiver[];
+    getSenders(): RTCRtpSender[];
+    getTransceivers(): RTCRtpTransceiver[];
+    addTrack(track: MediaStreamTrack, ...streams: MediaStream[]): RTCRtpSender;
+    removeTrack(sender: RTCRtpSender): void;
+    ontrack: ((this: RTCPeerConnection, ev: RTCTrackEvent) => any) | null;
 }
-
-export interface RTPMediaExtensions extends Pick<
-  RTCPeerConnection & RTPMediaExtensionsEventTarget,
-  | 'getSenders'
-  | 'getReceivers'
-  | 'getTransceivers'
-  | 'addTrack'
-  | 'removeTrack'
-  | 'addTransceiver'
-  | 'addEventListener'
-  | 'removeEventListener'
-  | 'ontrack'
-> {}
 


### PR DESCRIPTION
This fixes an issue where the RTPMediaExtensions inferface would be empty in the TypeDoc output. By explicitly redefining these, we can now see the structure of the RTPMediaExtensions interface in the docs.

See https://github.com/TypeStrong/typedoc/issues/156#issuecomment-674282376 for more information.