### PR TITLE
chore(github): fix docs.yml / deploy-docs:

### DIFF
--- a/bin/deploy-docs
+++ b/bin/deploy-docs
@@ -2,7 +2,7 @@
 set -e
 
 HEAD=$(git rev-parse --short HEAD)
-REMOTE=$(git remote get-url origin)
+REMOTE=$(cat package.json | ruby -r json -e 'puts JSON.parse(ARGF.read)["repository"]["url"]')
 VERSION=$(cat package.json | ruby -r json -e 'puts JSON.parse(ARGF.read)["version"]')
 
 npm run doc

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/paradigmpost/rtcpeer.git"
+    "url": "git@github.com:paradigmpost/rtcpeer.git"
   },
   "author": "Samuel Moore <sam@paradigmpost.com>",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
- make package.json's repository URL a valid git/ssh URL
- use package.json as source for remote URL when deploying docs for CI servers